### PR TITLE
Add "Accept: application/json" to the headers of ExtJS Ajax calls

### DIFF
--- a/Tpg/ExtjsBundle/Resources/views/ExtjsMarkup/remoteapi.js.twig
+++ b/Tpg/ExtjsBundle/Resources/views/ExtjsMarkup/remoteapi.js.twig
@@ -1,3 +1,4 @@
+Ext.Ajax.defaultHeaders = {'Accept': 'application/json'};
 Ext.require([
     'Ext.direct.Manager',
     'Ext.direct.RemotingProvider'


### PR DESCRIPTION
Without this header it didn't work for us, because ExtJS Ajax calls where sent using an "Accept: text/html" header and the format detection of FOSRestBundle got confused by this
