### PR TITLE
fix of big problem in GenerateRestControllerCommand::getSkeletonDirs

### DIFF
--- a/Command/GenerateRestControllerCommand.php
+++ b/Command/GenerateRestControllerCommand.php
@@ -148,7 +148,7 @@ EOT
     protected function getSkeletonDirs(BundleInterface $bundle = null)
     {
         $dirs = parent::getSkeletonDirs($bundle);
-        array_unshift($dirs, __DIR__.'/../Resources/skeleton');
+        $dirs[] = __DIR__.'/../Resources/skeleton';
         return $dirs;
     }
 


### PR DESCRIPTION
Sorry for my English. We have opportunity to change generated controller's template. But, method "getSkeletonDirs" insert bundle's directory in top of directory list. I change it to insert into the end.
