### PR TITLE
problem with slashes in model template

### DIFF
--- a/Resources/views/ExtjsMarkup/model.js.twig
+++ b/Resources/views/ExtjsMarkup/model.js.twig
@@ -89,7 +89,7 @@ Ext.define("{{ name }}", {
     ],
     {%- if proxy %}
 
-    proxy: {{ proxy|json_encode|raw }}
+    proxy: {{ proxy|json_encode(constant('JSON_UNESCAPED_SLASHES'))|raw }}
 
     {%- else %}
 


### PR DESCRIPTION
sorry for my english. When i tried to generate model, property proxy.url was like "api\/phones". But with JSON_UNESCAPED_SLASHES constant everything works properly
