### PR TITLE
fix for entity-file search in GeneratorController

### DIFF
--- a/Controller/GeneratorController.php
+++ b/Controller/GeneratorController.php
@@ -26,7 +26,7 @@ class GeneratorController extends Controller {
                         /** Entity end with backslash, it is a directory */
                         $bundleRef = new \ReflectionClass($bundle);
                         $dir = new Finder();
-                        $dir->files()->in(dirname($bundleRef->getFileName()).'/'.$path)->name('/.*\.php$/');
+                        $dir->files()->depth('== 0')->in(dirname($bundleRef->getFileName()).'/'.$path)->name('/.*\.php$/');
                         foreach($dir as $file) {
                             $entityClassname = $bundleRef->getNamespaceName() . "\\" . str_replace("/", "\\", $path) . substr($file->getFilename(), 0, -4);
                             echo $generator->generateMarkupForEntity($entityClassname);


### PR DESCRIPTION
if i have sub directories in Entity directory, method
generateModelAction try to find ALL files under Entity dir., but it
makes wrong namespaces, because use only file's name. It is not a
solution, but it removes error
