### PR TITLE
Fixed missing required bundle

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ public function registerBundles()
 {
     $bundles = array(
         // ...
+        new JMS\SerializerBundle\JMSSerializerBundle(),
         new \Tpg\ExtjsBundle\TpgExtjsBundle(),
     );
 }


### PR DESCRIPTION
If you installing just as folows you get `ParameterNotFoundException`, since required parameter from `JMSSerializerBundle` is missing in `services.xml`
